### PR TITLE
Mark font files binary, to exclude from EOL rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Always use LF for line endings
 * text eol=lf
+# Apart from font files
+*.[ot]tf binary


### PR DESCRIPTION
Resolves #348 