### PR TITLE
adjusted aria-label for defence toggles

### DIFF
--- a/frontend/src/components/DefenceBox/DefenceMechanism.tsx
+++ b/frontend/src/components/DefenceBox/DefenceMechanism.tsx
@@ -75,7 +75,7 @@ function DefenceMechanism({
             onChange={toggleDefence}
             // set checked if defence is active
             checked={defenceDetail.isActive}
-            aria-label="toggle defence"
+            aria-label={defenceDetail.name}
           />
           <span className="slider round"></span>
         </label>


### PR DESCRIPTION
### Updated:
Adjusted the aria-labels so that they now contain the name of the defence they toggle. 

**Acceptance Criteria:**
- Users can tell from the aria-label on the defence toggles, which defences they toggle on and off.

Screenshot of aria-label showing up with defence name in dom tree
![image](https://github.com/ScottLogic/prompt-injection/assets/125262707/2b858de2-ced5-4a3a-b209-9da1db4645a7)
