### PR TITLE
aria-hidden added to span preventing double narration

### DIFF
--- a/frontend/src/components/DefenceBox/DefenceMechanism.tsx
+++ b/frontend/src/components/DefenceBox/DefenceMechanism.tsx
@@ -67,7 +67,7 @@ function DefenceMechanism({
   return (
     <details className="defence-mechanism">
       <summary>
-        <span>{defenceDetail.name}</span>
+        <span aria-hidden>{defenceDetail.name}</span>
         <label className="switch">
           <input
             type="checkbox"


### PR DESCRIPTION
## Updated
- aria-hidden added to the span, so that it doesn't read out the span, since the name is already picked up through the aria-label

## Good To know
We wouldn't need an aria label on the radio button at all if we moved the span inside the label tag, however, that changes the layout and would need more css refactoring, so this is an easy fix solution. 

## Screenshot of accessibility tree where the bug is fixed
![image](https://github.com/ScottLogic/prompt-injection/assets/125262707/9cab0ee7-af48-4e3d-87db-e96a14c35fe7)
