### PR TITLE
added aria-hidden to svgs

### DIFF
--- a/frontend/src/components/MainComponent/HandbookIcon.tsx
+++ b/frontend/src/components/MainComponent/HandbookIcon.tsx
@@ -1,6 +1,7 @@
 function HandbookIcon() {
   return (
     <svg
+      aria-hidden
       width="25"
       height="29"
       viewBox="0 0 25 29"

--- a/frontend/src/components/MainComponent/ProjectIcon.tsx
+++ b/frontend/src/components/MainComponent/ProjectIcon.tsx
@@ -1,6 +1,7 @@
 function ProjectIcon() {
   return (
     <svg
+      aria-hidden
       width="100%"
       height="100%"
       viewBox="0 0 385 355"

--- a/frontend/src/components/MainComponent/ProjectIconDark.tsx
+++ b/frontend/src/components/MainComponent/ProjectIconDark.tsx
@@ -1,6 +1,7 @@
 function ProjectIconDark() {
   return (
     <svg
+      aria-hidden
       width="100%"
       height="100%"
       viewBox="0 0 385 355"

--- a/frontend/src/components/MainComponent/ProjectIconWon.tsx
+++ b/frontend/src/components/MainComponent/ProjectIconWon.tsx
@@ -1,6 +1,7 @@
 function ProjectIconWon() {
   return (
     <svg
+      aria-hidden
       width="100%"
       height="100%"
       viewBox="0 0 385 355"


### PR DESCRIPTION
## Updated
Added aria-hidden to the svgs:
- for the Spy Logic logo (because it is purely decorative)
- for the handbook button icon (because the button itself is already identified by screenreaders and the icon which is wrapped inside the button therefore decorative only as well). The Handbook button itself does not get ignored this way, it still reads out "Open the handbook, button"

## Screenshots showing the ignored svgs in the accessibility tree
![image](https://github.com/ScottLogic/prompt-injection/assets/125262707/d34f3eee-b932-458c-a106-f5e86b654fa5)

![image](https://github.com/ScottLogic/prompt-injection/assets/125262707/a8b80447-262f-475c-8cfa-5fa5016c0272)
