### PR TITLE
fixes bug by introducting height 1 px to chatBoxFeed

### DIFF
--- a/frontend/src/components/ChatBox/ChatBoxFeed.css
+++ b/frontend/src/components/ChatBox/ChatBoxFeed.css
@@ -5,4 +5,5 @@
   overflow-y: auto;
   scrollbar-width: thin;
   padding: 0 2rem;
+  height: 1px;
 }


### PR DESCRIPTION
fixes [bug](https://github.com/ScottLogic/prompt-injection/issues/427#issuecomment-1785952732) found in #427 

stops the scroll going all weird when the chatbox fills up