### PR TITLE
adjusted button that lets you switch between story and sandbox mode so that it flexes

### DIFF
--- a/frontend/src/components/ThemedButtons/ThemedButton.css
+++ b/frontend/src/components/ThemedButtons/ThemedButton.css
@@ -5,8 +5,7 @@
   padding: 0.5rem;
   color: var(--main-button-inactive-text-colour);
   cursor: pointer;
-  white-space: nowrap;
-  /* centre content */
+  height: fit-content;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Description
The button that lets you switch between story and sandbox mode was overflowing easily, this should fix that.

## Updated: 
removed nowrap from themed-button class and added height: fit-content so that the changing mode buttons flexes. 

## Screenshot before
![image](https://github.com/ScottLogic/prompt-injection/assets/125262707/93c2ef84-e566-4878-8a50-64d5e16edfb7)

## Screenshot after
![image](https://github.com/ScottLogic/prompt-injection/assets/125262707/df6a59b1-cd4b-4ad2-890d-cc5ed0411964)


