### PR TITLE
491 chat bubble bug

### DIFF
--- a/frontend/src/components/ChatBox/ChatBoxMessage.css
+++ b/frontend/src/components/ChatBox/ChatBoxMessage.css
@@ -4,7 +4,7 @@
   margin-top: 1rem;
   padding: 0.5rem;
   max-width: 85%;
-  width: max-content;
+  width: fit-content;
   -webkit-hyphens: auto;
   -moz-hyphens: auto;
   -ms-hyphens: auto;


### PR DESCRIPTION
## Description
Speech Bubble Bug - chat message speech bubble had too much whitespace.

## AC
Given the bot chats to you
When the bot message is short, 
Then the message is displayed without a lot of whitespace. 

## Before
![image](https://github.com/ScottLogic/prompt-injection/assets/125262707/cae4c8e9-2da4-41ca-b11c-3eb727d68dca)

## After
![image](https://github.com/ScottLogic/prompt-injection/assets/125262707/0b66e8c3-6895-469f-8ba8-0db17d067c5c)
