### PR TITLE
494 exported chat messages have wrong alignment

### DIFF
--- a/frontend/src/components/ExportChat/ExportChatMessage.tsx
+++ b/frontend/src/components/ExportChat/ExportChatMessage.tsx
@@ -2,7 +2,7 @@ import { Text, View, StyleSheet } from "@react-pdf/renderer";
 import { CHAT_MESSAGE_TYPE, ChatMessage } from "../../models/chat";
 
 const styles = StyleSheet.create({
-  chatBoxMessage: {
+  chatBoxMessageBot: {
     borderColor: "#888",
     borderRadius: 8,
     borderStyle: "solid",
@@ -16,7 +16,7 @@ const styles = StyleSheet.create({
     float: "left",
     textAlign: "left",
   },
-  chatBoxMessageBot: {
+  chatBoxMessage: {
     borderColor: "#888",
     borderRadius: 8,
     borderStyle: "solid",

--- a/frontend/src/components/ExportChat/ExportContent.tsx
+++ b/frontend/src/components/ExportChat/ExportContent.tsx
@@ -70,7 +70,7 @@ function ExportContent({
     if (currentLevel === LEVEL_NAMES.SANDBOX) {
       return `${title} (sandbox mode)`;
     } else {
-      return `${title} (level ${currentLevel})`;
+      return `${title} (level ${currentLevel + 1})`;
     }
   }
 


### PR DESCRIPTION
addresses #494

- Switches alignment of bot and user messages
- fixes title [displays correct level number (not zero indexed)]

![image](https://github.com/ScottLogic/prompt-injection/assets/118171430/a5d96e67-27c2-45e0-b4fb-fd343915432b)
