### PR TITLE
Fix textarea size bug on firefox

### DIFF
--- a/frontend/src/components/DefenceBox/DefenceMechanism.tsx
+++ b/frontend/src/components/DefenceBox/DefenceMechanism.tsx
@@ -96,13 +96,13 @@ function DefenceMechanism({
           <span className="slider round"></span>
         </label>
       </summary>
-      <div className="info-box" key={configKey}>
+      <div className="info-box">
         <p>{defenceDetail.info}</p>
         {showConfigurations &&
           defenceDetail.config.map((config) => {
             return (
               <DefenceConfiguration
-                key={config.id}
+                key={config.id + configKey}
                 isActive={defenceDetail.isActive}
                 config={config}
                 setConfigurationValue={setConfigurationValue}


### PR DESCRIPTION
On Firefox it looks like while the `textarea` is hidden (in this case within a collapsed `details` element), the `clientHeight`, `scrollHeight`, `offsetHeight` of the `textarea` is `0`. 
These values are used in the algorithm which calculates the `textarea` height. The zero values result in the tiny height seen in the issue.
To fix this, I added a key which forces a re-render of the configuration component when the `dialog` is toggled.