### PR TITLE
Fix css so main panel does not expand outside page

### DIFF
--- a/frontend/src/components/MainComponent/MainBody.css
+++ b/frontend/src/components/MainComponent/MainBody.css
@@ -1,7 +1,8 @@
 .main-area {
   display: flex;
   flex-direction: row;
-  height: 100%;
+  flex-grow: 1;
+  overflow: hidden;
 }
 
 .centre-area {

--- a/frontend/src/components/MainComponent/MainComponent.css
+++ b/frontend/src/components/MainComponent/MainComponent.css
@@ -3,11 +3,3 @@
   display: flex;
   flex-direction: column;
 }
-
-.main-component header {
-  height: 10%;
-}
-
-.main-component main {
-  height: 90%;
-}

--- a/frontend/src/components/MainComponent/MainFooter.css
+++ b/frontend/src/components/MainComponent/MainFooter.css
@@ -1,13 +1,19 @@
 .main-footer {
   width: 100%;
-  background-color: var(--footer-background-colour);
+  height: 3.75rem;
+  flex-shrink: 0;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  background-color: var(--footer-background-colour);
 }
 
-.main-footer svg {
+.main-footer > a {
+  display: flex;
+}
+
+.main-footer > a svg {
   height: 2.25rem;
   padding: 0.75rem;
 }

--- a/frontend/src/components/MainComponent/MainHeader.css
+++ b/frontend/src/components/MainComponent/MainHeader.css
@@ -5,8 +5,8 @@
   flex-direction: row;
   justify-content: space-between;
   padding: 0 2rem;
-  height: 100%;
-  min-height: 3.125rem;
+  height: 4rem;
+  flex-shrink: 0;
   font-family: "Helvetica Neue", Arial, Helvetica, sans-serif;
 }
 


### PR DESCRIPTION
After playing around with this with @pmarsh-scottlogic yesterday, we were scratching our heads a bit... Turns out we were simply missing an overflow:hidden on the main section 🤦‍♂️ 

Please verify this is working, when you expand and collapse the config panels on the left.