### PR TITLE
Lighter chat info text colour

### DIFF
--- a/frontend/src/Theme.css
+++ b/frontend/src/Theme.css
@@ -67,7 +67,7 @@
   --chat-edited-background: linear-gradient(var(--chat-edited-colour), #cae7f5);
   --chat-user-colour: var(--main-accent-colour);
   --chat-user-background: linear-gradient(var(--chat-user-colour), #8ad5da);
-  --chat-info-text-colour: #888;
+  --chat-info-text-colour: #b0b0b0;
   --chat-message-text-colour: #000;
   --chat-alerted-text-colour: teal;
   --chat-triggered-text-colour: var(--main-error-colour);


### PR DESCRIPTION
Lightened the chat info text that appears when the user toggles a defence. 
Did this to meet accessibility contrast standards.

## Screenshots

New look:

![image](https://github.com/ScottLogic/prompt-injection/assets/103250539/a61b9db1-13e7-4b05-90af-8a27e702b6c2)

Contrast checker:

![image](https://github.com/ScottLogic/prompt-injection/assets/103250539/c9f75d34-cc69-4590-b803-1589cf110c5e)
