### PR TITLE
Remove Title from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-# Title
-
 ## Description
 Describe what your code changes do.
 


### PR DESCRIPTION
## Description
Remove "Title" from the PR template.

## Notes
- It was a bit odd having 'Title' in the template, as it's displayed in the PR anyway. 
- No tests for this.

## Concerns
- Removing this leaves the other headers as second-order headers, without a first-order header (`##` without `#`). Is this a problem? 

## Checklist
Have you done the following?
- [x] Linked the relevant Issue 
- [x] Added tests
- [x] Ensured the workflow steps are passing
- [x] Requested reviews
