### PR TITLE
Use ES module loading in backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,4 +5,4 @@ RUN npm ci
 COPY . .
 EXPOSE 3001
 RUN npm run build
-CMD ["node", "./build/server.js"]
+CMD ["node", "--import=tsx/esm", "./build/server.js"]

--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -3,6 +3,7 @@ import type { JestConfigWithTsJest } from "ts-jest";
 const jestConfig: JestConfigWithTsJest = {
   moduleNameMapper: {
     "^@src/(.*)": "<rootDir>/src/$1",
+    importMetaUtils$: "<rootDir>/test/importMetaUtils.mock.ts",
   },
   modulePathIgnorePatterns: ["build", "coverage", "node_modules"],
   testEnvironment: "node",
@@ -10,12 +11,13 @@ const jestConfig: JestConfigWithTsJest = {
     "^.+\\.ts$": [
       "ts-jest",
       {
-        tsconfig: "test/tsconfig.json",
+        tsconfig: "./test/tsconfig.json",
+        useESM: true,
       },
     ],
   },
   silent: true,
-  setupFiles: ["<rootDir>/test/setupEnvVars.ts"],
+  setupFiles: ["./test/setupEnvVars.ts"],
 };
 
 export default jestConfig;

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "prompt-injection-api",
   "version": "0.1.0",
+  "type": "module",
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch -r dotenv/config src/server.ts",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,4 +1,4 @@
-import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import cors from "cors";
 import dotenv from "dotenv";
@@ -7,6 +7,7 @@ import session from "express-session";
 import memoryStoreFactory from "memorystore";
 
 import { defaultDefences } from "./defaultDefences";
+import { importMetaUrl } from "./importMetaUtils";
 import { ChatHistoryMessage, ChatModel, defaultChatModel } from "./models/chat";
 import { DefenceInfo } from "./models/defence";
 import { EmailInfo } from "./models/email";
@@ -83,7 +84,9 @@ app.use("/", router);
 // serve the documents folder
 app.use(
   "/documents",
-  express.static(join(__dirname, "@src/resources/documents/common"))
+  express.static(
+    fileURLToPath(new URL("../resources/documents/common", importMetaUrl()))
+  )
 );
 
 export default app;

--- a/backend/src/importMetaUtils.ts
+++ b/backend/src/importMetaUtils.ts
@@ -1,0 +1,9 @@
+/*
+  Wrap access to import.meta in own module, so can be mocked for tests.
+  ts-jest is not playing nicely :(
+  e.g. https://stackoverflow.com/q/64961387
+*/
+
+export function importMetaUrl() {
+  return import.meta.url;
+}

--- a/backend/test/importMetaUtils.mock.ts
+++ b/backend/test/importMetaUtils.mock.ts
@@ -1,0 +1,10 @@
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+/*
+ Unfortunately, Jest does not yet support "import.meta" syntax of ES Modules.
+ Can fake it for our tests:
+ */
+export function importMetaUrl() {
+  return pathToFileURL(join(process.cwd(), "src"));
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "module": "CommonJS",
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
     "allowJs": true,
     "outDir": "build",
     "strict": true,


### PR DESCRIPTION
## Description
Previously we were transpiling the back-end typescript code into CommonJS, which is unnecessary since around node v10. This PR corrects that, to define the back-end as an ES module, and transpile the typescript accordingly.

Resolves #323 

## Notes
- I've picked ES2022, as those features are widely supported since Node v14:
  https://node.green/

## Concerns
- [`__dirname` is not supported in ES modules](https://nodejs.org/docs/latest-v14.x/api/esm.html#esm_no_filename_or_dirname), instead we use `import.meta.url`, which is mostly fine...
- ... except that ts-jest does not yet support `import.meta`, despite claims to the contrary (the maintainer [closed the issue](https://github.com/kulshekhar/ts-jest/issues/3888) in a huff). So I have extracted the import.meta reading code into its own file, which we can mock in Jest.

## Checklist
Have you done the following?
- [x] Linked the relevant Issue 
- [x] Run regression tests
- [x] Ensured the workflow steps are passing
- [x] Requested reviews
