### PR TITLE
Fixed document path

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -85,7 +85,7 @@ app.use("/", router);
 app.use(
   "/documents",
   express.static(
-    fileURLToPath(new URL("../resources/documents/common", importMetaUrl()))
+    fileURLToPath(new URL("../resources/documents", importMetaUrl()))
   )
 );
 


### PR DESCRIPTION
## Description
Another fix for the document viewer.

## Screenshots
![image](https://github.com/ScottLogic/prompt-injection/assets/103250539/33eec7de-4392-491d-81ce-6e935987f2e5)

## Notes
- Had to exclude "common" from the document path.

## Checklist
Have you done the following?
- [x] Linked the relevant Issue 
- [ ] Added tests
- [x] Ensured the workflow steps are passing
- [x] Requested reviews
