### PR TITLE
add css import into HandbookOverlay

### DIFF
--- a/frontend/src/components/HandbookOverlay/HandbookOverlay.tsx
+++ b/frontend/src/components/HandbookOverlay/HandbookOverlay.tsx
@@ -10,6 +10,8 @@ import HandbookGlossary from './HandbookGlossary';
 import HandbookSpine from './HandbookSpine';
 import HandbookSystemRole from './HandbookSystemRole';
 
+import './HandbookOverlay.css';
+
 function HandbookOverlay({
 	currentLevel,
 	numCompletedLevels,


### PR DESCRIPTION
## Description

The css import was removed at some point (accidentally?) from the handbook overlay making it buggy
![image](https://github.com/ScottLogic/prompt-injection/assets/118981273/1064e968-0657-49a7-a14f-ef8d793b44de)

Added it back in

## Screenshots
![image](https://github.com/ScottLogic/prompt-injection/assets/118981273/7b395738-1327-4df6-8121-d77c2fa7ca57)

## Notes
- Bullet point list with 
- any notable code changes
- or explanations regarding this PR

## Concerns
- Bullet point list
- with any questions
- or concerns about this PR

## Checklist
Have you done the following?
- [ ] Linked the relevant Issue 
- [ ] Added tests
- [x] Ensured the workflow steps are passing
- [x] Requested reviews
