### PR TITLE
fix vitest stderr

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,5 +17,6 @@ export default defineConfig({
 		setupFiles: ['./vitest-setup.ts'],
 		reporters: process.env.CI ? ['default', 'junit'] : undefined,
 		outputFile: process.env.CI ? 'reports/test-output.xml' : undefined,
+		globals: true,
 	},
 });


### PR DESCRIPTION
We were getting this error when running the front end tests.
![image](https://github.com/ScottLogic/prompt-injection/assets/118171430/b08cce68-7f64-4ca9-a45d-2726a56b4bea)

This is the fix.
see [stackoverflow](https://stackoverflow.com/questions/77494496/vitest-warning-the-current-test-runner-does-not-support-aftereach-teardown-hook)
and [vitest docs](https://vitest.dev/config/#globals)