### PR TITLE
finish configuring vitest

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,7 +22,9 @@
 
 		"paths": {
 			"@src/*": ["./src/*"]
-		}
+		},
+
+		"types": ["vitest/globals"]
 	},
 	"exclude": ["node_modules", "dist"],
 	"include": ["*.ts", "src", ".eslintrc.cjs", "vite.config.ts"]


### PR DESCRIPTION
in #643 we enable the global APIs for vitest according to the [vitest docs](https://vitest.dev/config/#globals). However, while this solves the error we were getting, it is not recommended