### PR TITLE
714: Show error is we fail to reset defences

### DIFF
--- a/frontend/src/components/MainComponent/MainComponent.tsx
+++ b/frontend/src/components/MainComponent/MainComponent.tsx
@@ -226,6 +226,13 @@ function MainComponent({
 			configItemId,
 			currentLevel
 		);
+		if (!resetDefence) {
+			addChatMessage({
+				message: 'Failed to reset defence configuration. Please try again.',
+				type: 'ERROR_MSG',
+			});
+			return;
+		}
 		addConfigUpdateToChat(defenceId, 'reset');
 		// update state
 		const newDefences = defences.map((defence) => {

--- a/frontend/src/service/defenceService.ts
+++ b/frontend/src/service/defenceService.ts
@@ -85,7 +85,7 @@ async function resetDefenceConfigItem(
 			return (await response.json()) as DefenceResetResponse;
 		},
 		async () => {
-			return null;
+			return await null;
 		}
 	);
 }

--- a/frontend/src/service/defenceService.ts
+++ b/frontend/src/service/defenceService.ts
@@ -75,13 +75,19 @@ async function resetDefenceConfigItem(
 	defenceId: DEFENCE_ID,
 	configItemId: DEFENCE_CONFIG_ITEM_ID,
 	level: LEVEL_NAMES
-): Promise<DefenceResetResponse> {
-	const response = await post(`${PATH}/resetConfig`, {
+): Promise<DefenceResetResponse | null> {
+	return post(`${PATH}/resetConfig`, {
 		defenceId,
 		configItemId,
 		level,
-	});
-	return (await response.json()) as DefenceResetResponse;
+	}).then(
+		async (response) => {
+			return (await response.json()) as DefenceResetResponse;
+		},
+		async () => {
+			return null;
+		}
+	);
 }
 
 function validatePositiveNumberConfig(value: string) {

--- a/frontend/src/service/defenceService.ts
+++ b/frontend/src/service/defenceService.ts
@@ -84,8 +84,8 @@ async function resetDefenceConfigItem(
 		async (response) => {
 			return (await response.json()) as DefenceResetResponse;
 		},
-		async () => {
-			return await null;
+		() => {
+			return null;
 		}
 	);
 }


### PR DESCRIPTION
## Description

- When running the frontend only, attempting to 'reset' any of the defence configurations will result in an error message being displaying in the chat. 
- Fixes #714

## Screenshots

![Screenshot 2024-11-04 110448](https://github.com/user-attachments/assets/bc734278-f8d3-4ab5-9d52-478a666316e5)

## Notes

- Changes made to MainComponent.tsx: add chat message when resetDefence fails
- Changes to defenceService.ts: return null when DefenceResetResponse promise fails

## Concerns

- No unit tests added - may be irrelevant due to running only frontend 

## Checklist

Have you done the following?

- [x] Linked the relevant Issue
- [] Added tests
- [x] Ensured the workflow steps are passing
